### PR TITLE
py3compat.py fails flake8 tests on Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+python:
+    - 2.7
+    - 3.6
+install:
+    - pip install flake8  # pytest  # add some test later
+script:
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+notifications:
+    on_success: change
+    on_failure: change  # `always` will be the setting once code changes slow down

--- a/py3compat.py
+++ b/py3compat.py
@@ -24,22 +24,20 @@ _identity = lambda x: x
 
 # avoid flake8 F821 undefined name 'unicode'
 try:
-    unicode         # Python 2
+    text_type = unicode  # Python 2
+    string_types = (str, unicode)
 except NameError:
-    unicode = str   # Python 3
+    text_type = str      # Python 3
+    string_types = (str, )
 
 # avoid flake8 F821 undefined name 'xrange'
 try:
-    xrange          # Python 2
+    range_type = xrange  # Python 2
 except NameError:
-    xrange = range  # Python 3
+    range_type = range   # Python 3
 
 if not PY2:
     unichr = chr
-    range_type = range
-    text_type = str
-    string_types = (str,)
-
     iterkeys = lambda d: iter(d.keys())
     itervalues = lambda d: iter(d.values())
     iteritems = lambda d: iter(d.items())
@@ -65,16 +63,12 @@ if not PY2:
 
 else:
     unichr = unichr
-    text_type = unicode
-    range_type = xrange
-    string_types = (str, unicode)
-
     iterkeys = lambda d: d.iterkeys()
     itervalues = lambda d: d.itervalues()
     iteritems = lambda d: d.iteritems()
 
-    import cPickle as pickle
-    from cStringIO import StringIO as BytesIO, StringIO
+    import cPickle as pickle  # noqa
+    from cStringIO import StringIO as BytesIO, StringIO  # noqa
     NativeStringIO = BytesIO
 
     exec('def reraise(tp, value, tb=None):\n raise tp, value, tb')
@@ -95,8 +89,11 @@ else:
     get_next = lambda x: x.next
 
     def encode_filename(filename):
-        if isinstance(filename, unicode):
-            return filename.encode('utf-8')
+        try:  # avoid flake8 F821 undefined name 'unicode'
+            if isinstance(filename, unicode):
+                return filename.encode('utf-8')
+        except NameError:  # Python 3
+            pass
         return filename
 
 

--- a/py3compat.py
+++ b/py3compat.py
@@ -22,6 +22,17 @@ PY2 = str is bytes
 PYPY = hasattr(sys, 'pypy_translation_info')
 _identity = lambda x: x
 
+# avoid flake8 F821 undefined name 'unicode'
+try:
+    unicode         # Python 2
+except NameError:
+    unicode = str   # Python 3
+
+# avoid flake8 F821 undefined name 'xrange'
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
 
 if not PY2:
     unichr = chr

--- a/py3compat.py
+++ b/py3compat.py
@@ -58,7 +58,6 @@ if not PY2:
 
     implements_iterator = _identity
     implements_to_string = _identity
-    encode_filename = _identity
     get_next = lambda x: x.__next__
 
 else:
@@ -88,13 +87,15 @@ else:
 
     get_next = lambda x: x.next
 
-    def encode_filename(filename):
-        try:  # avoid flake8 F821 undefined name 'unicode'
-            if isinstance(filename, unicode):
-                return filename.encode('utf-8')
-        except NameError:  # Python 3
-            pass
-        return filename
+
+def encode_filename(filename):
+    # avoid flake8 F821 undefined name 'unicode'
+    try:               # Python 2
+        if isinstance(filename, unicode):
+            return filename.encode('utf-8')
+    except NameError:  # Python 3
+        pass
+    return filename
 
 
 def with_metaclass(meta, *bases):


### PR DESCRIPTION
py3compat.py fails flake8 tests on Python 3 so all of the _many_ other projects that vendor in py3compat.py also fail flake8 tests on Python 3.